### PR TITLE
Secured api_key, changed layout Background

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,7 @@
 REACT_APP_RAPID_API_KEY = <KEY>
+
+# use Process.env.REACT_APP_RAPID_API_KEY in fetFromAPI.js to fetch data from api by using RAPID_API_KEY stored in .env file 
+# you can use RAPID_API_KEY = '01fb8d7063msh3ad668189e06297p108423jsn1f30a28cfb1a',
+# or use your own api key
+
+# and don't forget to put .env in .gitignore

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -3,7 +3,7 @@ import Navbar from "./Navbar";
 import { Box } from "@mui/material";
 
 const Layout = () => (
-    <Box sx={{ backgroundColor: '#000' }}>
+    <Box sx={{ backgroundColor: '#212427' }}>
         <Navbar />
         <Outlet />
     </Box>

--- a/src/utils/fetchFromAPI.js
+++ b/src/utils/fetchFromAPI.js
@@ -7,7 +7,7 @@ const options = {
   url: 'https://youtube-v31.p.rapidapi.com/captions',
   params: {part: 'snippet', videoId: 'M7FIvfx5J10'},
   headers: {
-    'X-RapidAPI-Key': '01fb8d7063msh3ad668189e06297p108423jsn1f30a28cfb1a',
+    'X-RapidAPI-Key': process.env.RAPID_API_KEY || '01fb8d7063msh3ad668189e06297p108423jsn1f30a28cfb1a',
     'X-RapidAPI-Host': 'youtube-v31.p.rapidapi.com'
   }
 };


### PR DESCRIPTION
Let's secure the RAPID_API_KEY by storing it inside a .env file and put it in .gitignore. All details are mentioned in .env.example file. If other devs are willing to bring this change then remove the 'X-RapidAPI-Key' from fetchFromAPI.js file. 
And I have changed the layout background from proper black #000 to a light darker (more suitable for human eyes) colour.